### PR TITLE
feat: allow custom `transformFn` param

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,16 @@
 
 Typescript support for [i18next-scanner](https://github.com/i18next/i18next-scanner/)
 
-
 ## Install
 
-```
+```bash
 yarn add -D i18next-scanner-typescript
 ```
 
-
 ## Usage
 
-```
-var typescriptTransform = require('i18next-scanner-typescript');
+```js
+const typescriptTransform = require('i18next-scanner-typescript');
 
 module.exports = {
   options: {
@@ -29,15 +27,22 @@ module.exports = {
   // your i18next-scanner config
   // ...
   transform: typescriptTransform({
-      // default value for extensions
-      extensions: [".tsx"],
-      // optional ts configuration
-      tsOptions: {
-        target: "es2017",
-      },
+    // default value for extensions
+    extensions: [".ts", ".tsx"],
+    // optional ts configuration
+    tsOptions: {
+      target: "es2017",
+    },
+    // optional custom transform function
+    function customTransform(outputText, file, enc, done) {
+      // do something custom with the transpiled `outputText`
+      parser.parseTransFromString(outputText);
+      parser.parseFuncFromString(outputText});
+
+      done();
+    },
   }),
 };
-
 ```
 
 Double check that you don't have TS extensions in the non-transform configuration

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ module.exports = function typescriptTransform(
     },
     extensions: [".ts", ".tsx"],
   }
+  transformFn,
 ) {
   return function transform(file, enc, done) {
     const { base, ext } = path.parse(file.path);
@@ -20,6 +21,11 @@ module.exports = function typescriptTransform(
         compilerOptions: options.tsOptions,
         fileName: path.basename(file.path),
       });
+
+      if (typeof transformFn === 'function') {
+        transformFn.call(this, outputText, file, enc, done);
+        return;
+      }
 
       this.parser.parseTransFromString(outputText);
       this.parser.parseFuncFromString(outputText);


### PR DESCRIPTION
allows the user to use a custom transform function with with the `outputText` from ts transpile. which is required for example when using a custom transformer that checks which default namespace is set in `i18next-react` with `useTranslation`