### PR TITLE
set typescript as peer dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,11 @@
   "author": "Igor Adrov",
   "license": "MIT",
   "private": false,
-  "dependencies": {
+  "devDependencies": {
     "typescript": "^5.3.2"
+  },
+  "peerDependencies": {
+    "typescript": "5.x"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
When using this project with your own typescript `npm` installs two versions of `typescript`. 
So for dev purposes need to use `devDependencies` and also need `peer deps` for set that typescript is required